### PR TITLE
DBアクセス失敗時の例外ハンドリングを改善

### DIFF
--- a/src/main/java/nablarch/common/handler/DbConnectionManagementHandler.java
+++ b/src/main/java/nablarch/common/handler/DbConnectionManagementHandler.java
@@ -81,28 +81,15 @@ public class DbConnectionManagementHandler implements Handler<Object, Object>, I
 
         before();
 
-        Throwable throwable = null;
         try {
             return ctx.handleNext(inputData);
-        } catch (RuntimeException e) {
-            throwable = e;
-            throw e;
-        } catch (Error e) {
-            throwable = e;
-            throw e;
         } finally {
             try {
                 after();
             } catch (RuntimeException e) {
-                writeWarnLog(throwable);
-                if(throwable == null) {
-                    throw e;
-                }
+                writeWarnLog(e);
             } catch (Error e) {
-                writeWarnLog(throwable);
-                if(throwable == null) {
-                    throw e;
-                }
+                writeWarnLog(e);
             }
         }
     }

--- a/src/main/java/nablarch/common/handler/DbConnectionManagementHandler.java
+++ b/src/main/java/nablarch/common/handler/DbConnectionManagementHandler.java
@@ -95,10 +95,14 @@ public class DbConnectionManagementHandler implements Handler<Object, Object>, I
                 after();
             } catch (RuntimeException e) {
                 writeWarnLog(throwable);
-                throw e;
+                if(throwable == null) {
+                    throw e;
+                }
             } catch (Error e) {
                 writeWarnLog(throwable);
-                throw e;
+                if(throwable == null) {
+                    throw e;
+                }
             }
         }
     }

--- a/src/main/java/nablarch/common/handler/DbConnectionManagementHandler.java
+++ b/src/main/java/nablarch/common/handler/DbConnectionManagementHandler.java
@@ -111,6 +111,7 @@ public class DbConnectionManagementHandler implements Handler<Object, Object>, I
     /**
      * 復路処理を行う。
      *
+     * <p>
      * {@link DbConnectionContext}からデータベース接続を削除し、リソースの開放処理を行う。
      */
     public void after() {

--- a/src/test/java/nablarch/common/handler/DbConnectionManagementHandlerOnDbTest.java
+++ b/src/test/java/nablarch/common/handler/DbConnectionManagementHandlerOnDbTest.java
@@ -307,6 +307,7 @@ public class DbConnectionManagementHandlerOnDbTest {
         }
 
         // 元例外をアサート
+        assertWarnLogCountIs(1);
         assertWarnLog("java.lang.RuntimeException: terminate error!!!");
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
@@ -361,6 +362,7 @@ public class DbConnectionManagementHandlerOnDbTest {
         }
 
         // 元例外をアサート
+        assertWarnLogCountIs(1);
         assertWarnLog("java.lang.RuntimeException: terminate error!!!");
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
@@ -414,6 +416,7 @@ public class DbConnectionManagementHandlerOnDbTest {
         }
 
         // 元例外をアサート
+        assertWarnLogCountIs(1);
         assertWarnLog("java.lang.Error: error.");
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
@@ -468,8 +471,8 @@ public class DbConnectionManagementHandlerOnDbTest {
         }
 
         // 元例外をアサート
-        assertWarnLog(
-                "java.lang.Error: error.");
+        assertWarnLogCountIs(1);
+        assertWarnLog("java.lang.Error: error.");
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
         assertRemoveConnection();

--- a/src/test/java/nablarch/common/handler/DbConnectionManagementHandlerOnDbTest.java
+++ b/src/test/java/nablarch/common/handler/DbConnectionManagementHandlerOnDbTest.java
@@ -129,6 +129,8 @@ public class DbConnectionManagementHandlerOnDbTest {
             assertThat(e.getMessage(), is("error!!"));
         }
 
+        assertWarnLogCountIs(0);
+
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
         assertRemoveConnection();
     }
@@ -137,7 +139,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * {@link DbConnectionManagementHandler#handle(Object, nablarch.fw.ExecutionContext)}の異常系テスト。
      * <br/>
      * ケース内容:DbConnectionManagementHandlerのfinally句でRuntimeExceptionが発生した場合。<br/>
-     * 期待値:finally句で発生した例外がthrowされてくる。<br/>
+     * 期待値:例外がスローされず、正常終了する。<br/>
      *
      * @throws Exception
      */
@@ -166,12 +168,11 @@ public class DbConnectionManagementHandlerOnDbTest {
             connection.terminate();
             result = new RuntimeException("terminate error!!!");
         }};
-        try {
-            handler.handle(null, context);
-            fail("does not run.");
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is("terminate error!!!"));
-        }
+
+        handler.handle(null, context);
+
+        assertWarnLogCountIs(1);
+        assertWarnLog("java.lang.RuntimeException: terminate error!!");
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
         assertRemoveConnection();
@@ -193,7 +194,7 @@ public class DbConnectionManagementHandlerOnDbTest {
         List<Handler<?, ?>> handlers = new ArrayList<Handler<?, ?>>();
         handlers.add(new Handler<Object, Object>() {
             public Object handle(Object o, ExecutionContext context) {
-                throw new ArrayIndexOutOfBoundsException("hoge");
+                throw new OutOfMemoryError("hoge");
             }
         });
         ExecutionContext context = new ExecutionContext();
@@ -204,9 +205,11 @@ public class DbConnectionManagementHandlerOnDbTest {
         try {
             handler.handle(null, context);
             fail("does not run.");
-        } catch (Exception e) {
+        } catch (OutOfMemoryError e) {
             assertThat(e.getMessage(), is("hoge"));
         }
+
+        assertWarnLogCountIs(0);
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
         assertRemoveConnection();
@@ -216,7 +219,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * {@link DbConnectionManagementHandler#handle(Object, nablarch.fw.ExecutionContext)}の異常系テスト。
      * <br/>
      * ケース内容:DbConnectionManagementHandlerのfinally句でErrorが発生した場合。<br/>
-     * 期待値:finally句で発生したErrorがthrowされてくる。<br/>
+     * 期待値:Errorはスローされず正常終了する。<br/>
      *
      * @throws Exception
      */
@@ -247,14 +250,12 @@ public class DbConnectionManagementHandlerOnDbTest {
             result = new Error("error.");
         }};
 
-        try {
-            handler.handle(null, context);
-            fail("does not run.");
-        } catch (Error e) {
-            assertThat(e.getMessage(), is("error."));
-        }
+        handler.handle(null, context);
 
-        // 例外が発生してもスレッドコンテキストから削除されていることを確認
+        assertWarnLogCountIs(1);
+        assertWarnLog("java.lang.Error: error.");
+
+        // スレッドコンテキストから削除されていることを確認
         assertRemoveConnection();
     }
 
@@ -264,8 +265,8 @@ public class DbConnectionManagementHandlerOnDbTest {
      * ケース内容:ハンドラと、DbConnectionManagementHandlerのfinally句でRuntimeExceptionが発生した場合。<br/>
      * 期待値:
      * <ol>
-     * <li>finally句で発生した例外が送出されてくることを確認する。</li>
-     * <li>ハンドラで発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
+     * <li>ハンドラで発生した例外が送出されてくることを確認する。</li>
+     * <li>finally句で発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
      * </ol>
      *
      * @throws Exception
@@ -301,12 +302,12 @@ public class DbConnectionManagementHandlerOnDbTest {
         try {
             handler.handle(null, context);
             fail("does not run.");
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is("terminate error!!!"));
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), is("runtime error."));
         }
 
         // 元例外をアサート
-        assertWarnLog("java.lang.NullPointerException.*runtime error.");
+        assertWarnLog("java.lang.RuntimeException: terminate error!!!");
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
         assertRemoveConnection();
@@ -318,8 +319,8 @@ public class DbConnectionManagementHandlerOnDbTest {
      * ケース内容:ハンドラでErrorが発生し、DbConnectionManagementHandlerのfinally句でRuntimeExceptionが発生した場合。<br/>
      * 期待値:<br/>
      * <ol>
-     * <li>finally句で発生した例外が送出されてくることを確認する。</li>
-     * <li>ハンドラで発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
+     * <li>ハンドラで発生した例外が送出されてくることを確認する。</li>
+     * <li>finally句で発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
      * </ol>
      *
      * @throws Exception
@@ -355,12 +356,12 @@ public class DbConnectionManagementHandlerOnDbTest {
         try {
             handler.handle(null, context);
             fail("does not run.");
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is("terminate error!!!"));
+        } catch (OutOfMemoryError e) {
+            assertThat(e.getMessage(), is("out of memory error."));
         }
 
         // 元例外をアサート
-        assertWarnLog("java.lang.OutOfMemoryError.*out of memory error.");
+        assertWarnLog("java.lang.RuntimeException: terminate error!!!");
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
         assertRemoveConnection();
@@ -372,8 +373,8 @@ public class DbConnectionManagementHandlerOnDbTest {
      * ケース内容:ハンドラと、DbConnectionManagementHandlerのfinally句でErrorが発生した場合。<br/>
      * 期待値:<br/>
      * <ol>
-     * <li>finally句で発生した例外が送出されてくることを確認する。</li>
-     * <li>ハンドラで発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
+     * <li>ハンドラで発生した例外が送出されてくることを確認する。</li>
+     * <li>finally句で発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
      * </ol>
      *
      * @throws Exception
@@ -408,12 +409,12 @@ public class DbConnectionManagementHandlerOnDbTest {
         try {
             handler.handle(null, context);
             fail("does not run.");
-        } catch (Error e) {
-            assertThat(e.getMessage(), is("error."));
+        } catch (ClassFormatError e) {
+            assertThat(e.getMessage(), is("class format error."));
         }
 
         // 元例外をアサート
-        assertWarnLog("java.lang.ClassFormatError.*class format error.");
+        assertWarnLog("java.lang.Error: error.");
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
         assertRemoveConnection();
@@ -425,8 +426,8 @@ public class DbConnectionManagementHandlerOnDbTest {
      * ケース内容:ハンドラでRuntimeException、DbConnectionManagementHandlerのfinally句でErrorが発生した場合。<br/>
      * 期待値:<br/>
      * <ol>
-     * <li>finally句で発生した例外が送出されてくることを確認する。</li>
-     * <li>ハンドラで発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
+     * <li>ハンドラで発生した例外が送出されてくることを確認する。</li>
+     * <li>finally句で発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
      * </ol>
      *
      * @throws Exception
@@ -462,13 +463,13 @@ public class DbConnectionManagementHandlerOnDbTest {
         try {
             handler.handle(null, context);
             fail("does not run.");
-        } catch (Error e) {
-            assertThat(e.getMessage(), is("error."));
+        } catch (IndexOutOfBoundsException e) {
+            assertThat(e.getMessage(), is("java.lang.IndexOutOfBoundsException"));
         }
 
         // 元例外をアサート
         assertWarnLog(
-                "java.lang.IndexOutOfBoundsException.*java.lang.IndexOutOfBoundsException");
+                "java.lang.Error: error.");
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
         assertRemoveConnection();
@@ -531,6 +532,26 @@ public class DbConnectionManagementHandlerOnDbTest {
             }
         }
         assertThat("元例外がWARNレベルでログに出力されていること", writeLog, is(true));
+    }
+
+
+    /**
+     * ワーニングログの件数をアサートする。
+     *
+     * @param count ログのカウント
+     */
+    private static void assertWarnLogCountIs(int count){
+        List<String> log = OnMemoryLogWriter.getMessages("writer.memory");
+        int warnCount = 0;
+        for (String logMessage : log) {
+            String str = logMessage.replaceAll("[\\r\\n]", "");
+            if (str.matches(
+                    "^.*WARN.*failed in the "
+                            + "application process\\..*$")) {
+                warnCount++;
+            }
+        }
+        assertThat(warnCount, is(count));
     }
 
     /** {@link DbConnectionContext}からコネクションが削除されていることを確認する。 */

--- a/src/test/java/nablarch/common/handler/DbConnectionManagementHandlerOnDbTest.java
+++ b/src/test/java/nablarch/common/handler/DbConnectionManagementHandlerOnDbTest.java
@@ -1,7 +1,7 @@
 package nablarch.common.handler;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.text.MessageFormat;
@@ -51,7 +51,7 @@ public class DbConnectionManagementHandlerOnDbTest {
     /**
      * {@link DbConnectionManagementHandler#handle(Object, nablarch.fw.ExecutionContext)}のテスト
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void normalCase() throws Exception {
@@ -97,7 +97,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * ケース内容:ハンドラでRuntimeExceptionが発生した場合<br/>
      * 期待値:ハンドラで発生したRuntimeExceptionがthrowされてくる<br/>
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void handle_RuntimeException() throws Exception {
@@ -141,7 +141,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * ケース内容:DbConnectionManagementHandlerのfinally句でRuntimeExceptionが発生した場合。<br/>
      * 期待値:例外がスローされず、正常終了する。<br/>
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void finally_RuntimeException() throws Exception {
@@ -184,7 +184,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * ケース内容:ハンドラでErrorが発生した場合<br/>
      * 期待値:ハンドラで発生したErrorがthrowされてくる。<br/>
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void handle_Error() throws Exception {
@@ -221,7 +221,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * ケース内容:DbConnectionManagementHandlerのfinally句でErrorが発生した場合。<br/>
      * 期待値:Errorはスローされず正常終了する。<br/>
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void finally_Error() throws Exception {
@@ -269,7 +269,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * <li>finally句で発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
      * </ol>
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void handle_finally_RuntimeException() throws Exception {
@@ -323,7 +323,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * <li>finally句で発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
      * </ol>
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void handle_Error_finally_RuntimeException() throws Exception {
@@ -377,7 +377,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * <li>finally句で発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
      * </ol>
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void handle_finally_Error() throws Exception {
@@ -430,7 +430,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * <li>finally句で発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
      * </ol>
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void handle_RuntimeException_finally_Error() throws Exception {
@@ -529,6 +529,7 @@ public class DbConnectionManagementHandlerOnDbTest {
                     "^.*WARN.*DbConnectionManagementHandler.*failed in the "
                             + "application process\\..*" + message + ".*$")) {
                 writeLog = true;
+                break;
             }
         }
         assertThat("元例外がWARNレベルでログに出力されていること", writeLog, is(true));
@@ -560,6 +561,7 @@ public class DbConnectionManagementHandlerOnDbTest {
             DbConnectionContext.getConnection(TRANSACTION_NAME);
             fail("does not run.");
         } catch (IllegalArgumentException e) {
+            // NOP
         }
     }
 


### PR DESCRIPTION
- handle()内のfinally句で発生した例外を送出せず、handleNext()で発生した例外をそのまま送出するよう修正しました。
    - 修正の結果catch句が不要となったので、削除しています。
    - テストケースは、分岐パターンが網羅されていることを確認しています。今回のロジック修正に合わせ、合格条件変更
- テストコード内で出ていたインスペクションの警告に対応しました。
    - Javadocの修正
    - deprecatedなメソッドの置換
    - if文で条件が満たされたらbreakするようにする
    - 空のcatch句にコメント追加