### PR TITLE
finally句で握り潰しているErrorを伝播させる

### DIFF
--- a/src/main/java/nablarch/common/handler/DbConnectionManagementHandler.java
+++ b/src/main/java/nablarch/common/handler/DbConnectionManagementHandler.java
@@ -96,11 +96,11 @@ public class DbConnectionManagementHandler implements Handler<Object, Object>, I
             } catch (RuntimeException e) {
                 writeWarnLog(e);
             } catch (Error e) {
-                if(throwable instanceof Error){
+                if (throwable instanceof Error) {
                     writeWarnLog(e);
-                    throw (Error)throwable;
+                    throw (Error) throwable;
                 }
-                if(throwable != null) {
+                if (throwable != null) {
                     writeWarnLog(throwable);
                 }
                 throw e;

--- a/src/main/java/nablarch/common/handler/DbConnectionManagementHandler.java
+++ b/src/main/java/nablarch/common/handler/DbConnectionManagementHandler.java
@@ -81,15 +81,29 @@ public class DbConnectionManagementHandler implements Handler<Object, Object>, I
 
         before();
 
+        Throwable throwable = null;
         try {
             return ctx.handleNext(inputData);
+        } catch (RuntimeException e) {
+            throwable = e;
+            throw e;
+        } catch (Error e) {
+            throwable = e;
+            throw e;
         } finally {
             try {
                 after();
             } catch (RuntimeException e) {
                 writeWarnLog(e);
             } catch (Error e) {
-                writeWarnLog(e);
+                if(throwable instanceof Error){
+                    writeWarnLog(e);
+                    throw (Error)throwable;
+                }
+                if(throwable != null) {
+                    writeWarnLog(throwable);
+                }
+                throw e;
             }
         }
     }

--- a/src/test/java/nablarch/common/handler/DbConnectionManagementHandlerOnDbTest.java
+++ b/src/test/java/nablarch/common/handler/DbConnectionManagementHandlerOnDbTest.java
@@ -219,7 +219,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      * {@link DbConnectionManagementHandler#handle(Object, nablarch.fw.ExecutionContext)}の異常系テスト。
      * <br/>
      * ケース内容:DbConnectionManagementHandlerのfinally句でErrorが発生した場合。<br/>
-     * 期待値:Errorはスローされず正常終了する。<br/>
+     * 期待値:finally句で発生したErrorがthrowされてくる。<br/>
      *
      * @throws Exception Exception
      */
@@ -250,10 +250,14 @@ public class DbConnectionManagementHandlerOnDbTest {
             result = new Error("error.");
         }};
 
-        handler.handle(null, context);
+        try {
+            handler.handle(null, context);
+            fail("does not run.");
+        } catch (Error e) {
+            assertThat(e.getMessage(), is("error."));
+        }
 
-        assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.Error: error.");
+        assertWarnLogCountIs(0);
 
         // スレッドコンテキストから削除されていることを確認
         assertRemoveConnection();
@@ -429,8 +433,8 @@ public class DbConnectionManagementHandlerOnDbTest {
      * ケース内容:ハンドラでRuntimeException、DbConnectionManagementHandlerのfinally句でErrorが発生した場合。<br/>
      * 期待値:<br/>
      * <ol>
-     * <li>ハンドラで発生した例外が送出されてくることを確認する。</li>
-     * <li>finally句で発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
+     * <li>finally句で発生した例外が送出されてくることを確認する。</li>
+     * <li>ハンドラで発生した例外はワーニングレベルでログ出力されていることを確認する。</li>
      * </ol>
      *
      * @throws Exception Exception
@@ -466,13 +470,13 @@ public class DbConnectionManagementHandlerOnDbTest {
         try {
             handler.handle(null, context);
             fail("does not run.");
-        } catch (IndexOutOfBoundsException e) {
-            assertThat(e.getMessage(), is("java.lang.IndexOutOfBoundsException"));
+        } catch (Error e) {
+            assertThat(e.getMessage(), is("error."));
         }
 
         // 元例外をアサート
         assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.Error: error.");
+        assertWarnLog("java.lang.IndexOutOfBoundsException");
 
         // 例外が発生してもスレッドコンテキストから削除されていることを確認
         assertRemoveConnection();

--- a/src/test/java/nablarch/common/handler/DbConnectionManagementHandlerOnDbTest.java
+++ b/src/test/java/nablarch/common/handler/DbConnectionManagementHandlerOnDbTest.java
@@ -548,7 +548,7 @@ public class DbConnectionManagementHandlerOnDbTest {
      *
      * @param count ログのカウント
      */
-    private static void assertWarnLogCountIs(int count){
+    private static void assertWarnLogCountIs(int count) {
         List<String> log = OnMemoryLogWriter.getMessages("writer.memory");
         int warnCount = 0;
         for (String logMessage : log) {


### PR DESCRIPTION
#7 にてfinally句で発生した例外はワーニングログを出すのみで伝播させないように修正した。
しかし、Errorは発生した場合、通常アプリケーション続行不可能なためfinally句で握りつぶさず伝播させ適切なハンドラで補足するべきである。
そのため、以下の優先度で例外を送出するよう修正を行った。

1. 業務処理(handleNext)で発生したError
2. finally句の処理(after)で発生したError
3. 業務処理(handleNext)で発生したRuntimeException

finally句で発生したRuntimeExceptionについては #7 から変わらずワーニングログのみ出力し、伝播させない。
